### PR TITLE
fix: ...Event may only be triggered synchronously

### DIFF
--- a/plugin/src/main/java/com/mikedeejay2/simplestack/bytecode/transformers/advice/TransformBukkitItemStackGetMaxStackSize.java
+++ b/plugin/src/main/java/com/mikedeejay2/simplestack/bytecode/transformers/advice/TransformBukkitItemStackGetMaxStackSize.java
@@ -11,6 +11,7 @@ import net.bytebuddy.asm.AsmVisitorWrapper;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 
+import static com.mikedeejay2.simplestack.SimpleStack.getInstance;
 import static com.mikedeejay2.simplestack.bytecode.MappingsLookup.MappingEntry;
 import static com.mikedeejay2.simplestack.bytecode.MappingsLookup.nms;
 
@@ -40,7 +41,9 @@ public class TransformBukkitItemStackGetMaxStackSize implements MethodVisitorInf
 
     public static int getBukkitItemStackMaxStackSize(int currentReturnValue, long startTime, ItemStack itemStack) {
         final ItemStackMaxAmountEvent event = new ItemStackMaxAmountEvent(itemStack, currentReturnValue);
-        Bukkit.getPluginManager().callEvent(event);
+        Bukkit.getScheduler().runTask(getInstance(), () -> {
+            Bukkit.getPluginManager().callEvent(event);
+        });
         TIMINGS.collect(startTime, "Bukkit ItemStack size redirect", true);
         return event.getAmount();
     }

--- a/plugin/src/main/java/com/mikedeejay2/simplestack/bytecode/transformers/advice/TransformBukkitMaterialGetMaxStackSize.java
+++ b/plugin/src/main/java/com/mikedeejay2/simplestack/bytecode/transformers/advice/TransformBukkitMaterialGetMaxStackSize.java
@@ -11,6 +11,7 @@ import net.bytebuddy.asm.AsmVisitorWrapper;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 
+import static com.mikedeejay2.simplestack.SimpleStack.getInstance;
 import static com.mikedeejay2.simplestack.bytecode.MappingsLookup.MappingEntry;
 import static com.mikedeejay2.simplestack.bytecode.MappingsLookup.nms;
 
@@ -40,7 +41,9 @@ public class TransformBukkitMaterialGetMaxStackSize implements MethodVisitorInfo
 
     public static int getBukkitMaterialMaxStackSize(int currentReturnValue, long startTime, Material material) {
         final MaterialMaxAmountEvent event = new MaterialMaxAmountEvent(material, currentReturnValue);
-        Bukkit.getPluginManager().callEvent(event);
+        Bukkit.getScheduler().runTask(getInstance(), () -> {
+            Bukkit.getPluginManager().callEvent(event);
+        });
         TIMINGS.collect(startTime, "Bukkit Material size redirect", true);
         return event.getAmount();
     }

--- a/plugin/src/main/java/com/mikedeejay2/simplestack/bytecode/transformers/advice/TransformCraftBukkitItemStackGetMaxStackSize.java
+++ b/plugin/src/main/java/com/mikedeejay2/simplestack/bytecode/transformers/advice/TransformCraftBukkitItemStackGetMaxStackSize.java
@@ -11,6 +11,7 @@ import net.bytebuddy.asm.AsmVisitorWrapper;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 
+import static com.mikedeejay2.simplestack.SimpleStack.getInstance;
 import static com.mikedeejay2.simplestack.bytecode.MappingsLookup.MappingEntry;
 import static com.mikedeejay2.simplestack.bytecode.MappingsLookup.nms;
 
@@ -40,7 +41,9 @@ public class TransformCraftBukkitItemStackGetMaxStackSize implements MethodVisit
 
     public static int getCraftBukkitItemStackMaxStackSize(int currentReturnValue, long startTime, ItemStack itemStack) {
         final ItemStackMaxAmountEvent event = new ItemStackMaxAmountEvent(itemStack, currentReturnValue);
-        Bukkit.getPluginManager().callEvent(event);
+        Bukkit.getScheduler().runTask(getInstance(), () -> {
+            Bukkit.getPluginManager().callEvent(event);
+        });
         TIMINGS.collect(startTime, "CraftBukkit ItemStack size redirect", true);
         return event.getAmount();
     }

--- a/plugin/src/main/java/com/mikedeejay2/simplestack/bytecode/transformers/advice/TransformItemGetMaxStackSize.java
+++ b/plugin/src/main/java/com/mikedeejay2/simplestack/bytecode/transformers/advice/TransformItemGetMaxStackSize.java
@@ -9,6 +9,7 @@ import net.bytebuddy.asm.AsmVisitorWrapper;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 
+import static com.mikedeejay2.simplestack.SimpleStack.getInstance;
 import static com.mikedeejay2.simplestack.bytecode.MappingsLookup.*;
 
 /**
@@ -49,7 +50,9 @@ public class TransformItemGetMaxStackSize implements MethodVisitorInfo {
     public static int getItemMaxStackSize(int currentReturnValue, long startTime, Object nmsItem) {
         final Material material = NmsConverters.itemToMaterial(nmsItem);
         final MaterialMaxAmountEvent event = new MaterialMaxAmountEvent(material, currentReturnValue);
-        Bukkit.getPluginManager().callEvent(event);
+        Bukkit.getScheduler().runTask(getInstance(), () -> {
+            Bukkit.getPluginManager().callEvent(event);
+        });
         TIMINGS.collect(startTime, "Item size redirect", false);
         return event.getAmount();
     }

--- a/plugin/src/main/java/com/mikedeejay2/simplestack/bytecode/transformers/advice/TransformItemStackGetMaxStackSize.java
+++ b/plugin/src/main/java/com/mikedeejay2/simplestack/bytecode/transformers/advice/TransformItemStackGetMaxStackSize.java
@@ -9,6 +9,7 @@ import net.bytebuddy.asm.AsmVisitorWrapper;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 
+import static com.mikedeejay2.simplestack.SimpleStack.getInstance;
 import static com.mikedeejay2.simplestack.bytecode.MappingsLookup.*;
 
 /**
@@ -49,7 +50,9 @@ public class TransformItemStackGetMaxStackSize implements MethodVisitorInfo {
     public static int getItemStackMaxStackSize(int currentReturnValue, long startTime, Object nmsItemStack) {
         final ItemStack itemStack = NmsConverters.itemStackToItemStack(nmsItemStack);
         final ItemStackMaxAmountEvent event = new ItemStackMaxAmountEvent(itemStack, currentReturnValue);
-        Bukkit.getPluginManager().callEvent(event);
+        Bukkit.getScheduler().runTask(getInstance(), () -> {
+            Bukkit.getPluginManager().callEvent(event);
+        });
         TIMINGS.collect(startTime, "ItemStack size redirect", true);
         return event.getAmount();
     }

--- a/plugin/src/main/java/com/mikedeejay2/simplestack/bytecode/transformers/advice/TransformSlotGetMaxStackSize.java
+++ b/plugin/src/main/java/com/mikedeejay2/simplestack/bytecode/transformers/advice/TransformSlotGetMaxStackSize.java
@@ -12,6 +12,7 @@ import net.bytebuddy.asm.AsmVisitorWrapper;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.Inventory;
 
+import static com.mikedeejay2.simplestack.SimpleStack.getInstance;
 import static com.mikedeejay2.simplestack.bytecode.MappingsLookup.*;
 
 /**
@@ -41,7 +42,9 @@ public class TransformSlotGetMaxStackSize implements MethodVisitorInfo {
         final Inventory inventory = NmsConverters.slotToInventory(nmsSlot);
         final int slot = NmsConverters.slotToSlot(nmsSlot);
         final SlotMaxAmountEvent event = new SlotMaxAmountEvent(inventory, slot, currentReturnValue);
-        Bukkit.getPluginManager().callEvent(event);
+        Bukkit.getScheduler().runTask(getInstance(), () -> {
+            Bukkit.getPluginManager().callEvent(event);
+        });
         TIMINGS.collect(startTime, "Slot redirect", true);
         return event.getAmount();
     }

--- a/plugin/src/main/java/com/mikedeejay2/simplestack/bytecode/transformers/advice/TransformSlotISGetMaxStackSize.java
+++ b/plugin/src/main/java/com/mikedeejay2/simplestack/bytecode/transformers/advice/TransformSlotISGetMaxStackSize.java
@@ -13,6 +13,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
+import static com.mikedeejay2.simplestack.SimpleStack.getInstance;
 import static com.mikedeejay2.simplestack.bytecode.MappingsLookup.MappingEntry;
 import static com.mikedeejay2.simplestack.bytecode.MappingsLookup.nms;
 
@@ -45,7 +46,9 @@ public class TransformSlotISGetMaxStackSize implements MethodVisitorInfo {
         final int slot = NmsConverters.slotToSlot(nmsSlot);
         final ItemStack itemStack = nmsItemStack != null ? NmsConverters.itemStackToItemStack(nmsItemStack) : null;
         final SlotMaxAmountEvent event = new SlotMaxAmountEvent(inventory, slot, currentReturnValue, itemStack);
-        Bukkit.getPluginManager().callEvent(event);
+        Bukkit.getScheduler().runTask(getInstance(), () -> {
+            Bukkit.getPluginManager().callEvent(event);
+        });
         TIMINGS.collect(startTime, "Slot (ItemStack) redirect", true);
         return event.getAmount();
     }


### PR DESCRIPTION
~~Hi, After updating the server, I found that the plugin kept outputting errors, this change will fix it!~~

This will break the stacking functionality...

```
[08:51:00 ERROR]: Simple Stack encountered an exception while processing an Item
[08:51:00 WARN]: java.lang.IllegalStateException: MaterialMaxAmountEvent may only be triggered synchronously.
[08:51:00 WARN]:        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:50)
[08:51:00 WARN]:        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:126)
[08:51:00 WARN]:        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:617)
[08:51:00 WARN]:        at SimpleStack-2.0.0-DEV-SNAPSHOT.jar//com.mikedeejay2.simplestack.bytecode.transformers.advice.TransformItemGetMaxStackSize.getItemMaxStackSize(TransformItemGetMaxStackSize.java:52)
[08:51:00 WARN]:        at com.mikedeejay2.simplestack.bytecode.AdviceBridge.getItemMaxStackSize(AdviceBridge.java:111)
[08:51:00 WARN]:        at net.minecraft.world.item.Item.l(Item.java:156)
[08:51:00 WARN]:        at org.bukkit.craftbukkit.v1_20_R1.inventory.CraftItemStack.getMaxStackSize(CraftItemStack.java:174)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//io.github.thebusybiscuit.slimefun4.libraries.dough.inventory.InvUtils.isValidStackSize(InvUtils.java:70)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//io.github.thebusybiscuit.slimefun4.libraries.dough.inventory.InvUtils.fits(InvUtils.java:127)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//io.github.thebusybiscuit.slimefun4.libraries.dough.inventory.InvUtils.fitAll(InvUtils.java:158)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer.findNextRecipe(AContainer.java:429)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer.tick(AContainer.java:369)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer$3.tick(AContainer.java:338)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//io.github.thebusybiscuit.slimefun4.implementation.tasks.TickerTask.tickBlock(TickerTask.java:169)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//io.github.thebusybiscuit.slimefun4.implementation.tasks.TickerTask.tickLocation(TickerTask.java:156)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//io.github.thebusybiscuit.slimefun4.implementation.tasks.TickerTask.tickChunk(TickerTask.java:123)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//io.github.thebusybiscuit.slimefun4.implementation.tasks.TickerTask.run(TickerTask.java:100)
[08:51:00 WARN]:        at org.bukkit.craftbukkit.v1_20_R1.scheduler.CraftTask.run(CraftTask.java:101)
[08:51:00 WARN]:        at org.bukkit.craftbukkit.v1_20_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57)
[08:51:00 WARN]:        at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22)
[08:51:00 WARN]:        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
[08:51:00 WARN]:        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
[08:51:00 WARN]:        at java.base/java.lang.Thread.run(Thread.java:1589)
[08:51:00 ERROR]: Simple Stack encountered an exception while processing a CraftBukkit ItemStack
[08:51:00 WARN]: java.lang.IllegalStateException: ItemStackMaxAmountEvent may only be triggered synchronously.
[08:51:00 WARN]:        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:50)
[08:51:00 WARN]:        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:126)
[08:51:00 WARN]:        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:617)
[08:51:00 WARN]:        at SimpleStack-2.0.0-DEV-SNAPSHOT.jar//com.mikedeejay2.simplestack.bytecode.transformers.advice.TransformCraftBukkitItemStackGetMaxStackSize.getCraftBukkitItemStackMaxStackSize(TransformCraftBukkitItemStackGetMaxStackSize.java:43)
[08:51:00 WARN]:        at com.mikedeejay2.simplestack.bytecode.AdviceBridge.getCraftBukkitItemStackMaxStackSize(AdviceBridge.java:135)
[08:51:00 WARN]:        at org.bukkit.craftbukkit.v1_20_R1.inventory.CraftItemStack.getMaxStackSize(CraftItemStack.java:174)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//io.github.thebusybiscuit.slimefun4.libraries.dough.inventory.InvUtils.isValidStackSize(InvUtils.java:70)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//io.github.thebusybiscuit.slimefun4.libraries.dough.inventory.InvUtils.fits(InvUtils.java:127)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//io.github.thebusybiscuit.slimefun4.libraries.dough.inventory.InvUtils.fitAll(InvUtils.java:158)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer.findNextRecipe(AContainer.java:429)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer.tick(AContainer.java:369)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer$3.tick(AContainer.java:338)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//io.github.thebusybiscuit.slimefun4.implementation.tasks.TickerTask.tickBlock(TickerTask.java:169)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//io.github.thebusybiscuit.slimefun4.implementation.tasks.TickerTask.tickLocation(TickerTask.java:156)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//io.github.thebusybiscuit.slimefun4.implementation.tasks.TickerTask.tickChunk(TickerTask.java:123)
[08:51:00 WARN]:        at SF4_Slimefun-bf49fd8-Beta.jar//io.github.thebusybiscuit.slimefun4.implementation.tasks.TickerTask.run(TickerTask.java:100)
[08:51:00 WARN]:        at org.bukkit.craftbukkit.v1_20_R1.scheduler.CraftTask.run(CraftTask.java:101)
[08:51:00 WARN]:        at org.bukkit.craftbukkit.v1_20_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57)
[08:51:00 WARN]:        at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22)
[08:51:00 WARN]:        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
[08:51:00 WARN]:        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
[08:51:00 WARN]:        at java.base/java.lang.Thread.run(Thread.java:1589)

```